### PR TITLE
remove peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,5 @@
   "bugs": {
     "url": "https://github.com/quasarframework/quasar-extras/issues"
   },
-  "homepage": "https://github.com/quasarframework/quasar-extras#readme",
-  "peerDependencies": {
-    "quasar-framework": "^0.14.0"
-  }
+  "homepage": "https://github.com/quasarframework/quasar-extras#readme"
 }


### PR DESCRIPTION
I think it is better to make this package standalone as i prefer using this than the original [big]  `material-design-icons` and `roboto-fontface` packages on 0.13 version